### PR TITLE
Upload client app files to S3 using Terraform

### DIFF
--- a/terraform/webapp.tf
+++ b/terraform/webapp.tf
@@ -87,3 +87,32 @@ resource "aws_route53_record" "webapp" {
     evaluate_target_health = true
   }
 }
+
+# Build client app production bundle
+resource "null_resource" "build_client" {
+  depends_on = [
+    "aws_s3_bucket.webapp",
+  ]
+
+  provisioner "local-exec" {
+    working_dir = "${path.module}/../client"
+    command     = "yarn run build 1> /dev/null"
+  }
+}
+
+# Upload client app bundle to S3 bucket
+resource "null_resource" "upload_client" {
+  depends_on = [
+    "null_resource.build_client",
+  ]
+
+  provisioner "local-exec" {
+    working_dir = "${path.module}/../client/build"
+    command     = "aws s3 sync . s3://${aws_s3_bucket.webapp.bucket}"
+
+    environment {
+      AWS_ACCESS_KEY_ID     = "${var.access_key}"
+      AWS_SECRET_ACCESS_KEY = "${var.secret_key}"
+    }
+  }
+}


### PR DESCRIPTION
Resolves #11 

  - [x] Use Terraform `local-exec` provisioner for uploading client app files to `S3`